### PR TITLE
Fix compilation for Darwin i386, and hide "unused variable" notes

### DIFF
--- a/src/kraft.pas
+++ b/src/kraft.pas
@@ -114,6 +114,7 @@ unit kraft;
 {$longstrings on}
 {$booleval off}
 {$typeinfo on}
+{$notes off}
 
 {-$define UseMoreCollisionGroups}
 

--- a/src/kraft.pas
+++ b/src/kraft.pas
@@ -134,7 +134,11 @@ unit kraft;
  {$undef SIMD}
 {$else}
  {$ifdef cpu386}
-  {$define CPU386ASMForSinglePrecision}
+  {$ifndef DARWIN}
+   // Fails on Mac OS X with
+   // kraft.pas(4243,30) Error: Generating PIC, but reference is not PIC-safe
+   {$define CPU386ASMForSinglePrecision}
+  {$endif}
  {$endif}
  {$undef SIMD}
  {$ifdef CPU386ASMForSinglePrecision}


### PR DESCRIPTION
Testing compilation of Kraft on Darwin (Mac OS X) i386, I got multiple errors like

```
kraft.pas(4243,30) Error: Generating PIC, but reference is not PIC-safe
```

That's probably because on Darwin, compiling with PIC is the default (see the bottom of http://wiki.freepascal.org/PIC_information ). This pull request simply avoids defining `CPU386ASMForSinglePrecision` in this case.

Also, I added `{$notes off}`. Compiling Kraft.pas with notes enabled currently produces 37 notes about unused variables :)

```
kraft.pas(14151,27) Note: Local variable "NewStart" is assigned but never used
kraft.pas(14153,6) Note: Local variable "ti" is assigned but never used
```

It's not a big deal of course, but it makes the compiler output less useful when compiling a larger application with Kraft.pas inside.