### PR TITLE
Fix Android time issue

### DIFF
--- a/src/kraft.pas
+++ b/src/kraft.pas
@@ -162,6 +162,9 @@ uses {$ifdef windows}
        {$ifdef linux}
         linux,
        {$endif}
+       {$ifdef android}
+        linux,
+       {$endif}
       {$else}
        SDL,
       {$endif}
@@ -10409,10 +10412,14 @@ begin
 {$ifdef linux}
   fFrequency:=1000000000;
 {$else}
+{$ifdef android}
+  fFrequency:=1000000000;
+{$else}
 {$ifdef unix}
   fFrequency:=1000000;
 {$else}
   fFrequency:=1000;
+{$endif}
 {$endif}
 {$endif}
 {$endif}
@@ -10439,10 +10446,15 @@ function TKraftHighResolutionTimer.GetTime:int64;
 var NowTimeSpec:TimeSpec;
     ia,ib:int64;
 {$else}
+{$ifdef android}
+var NowTimeSpec:TimeSpec;
+    ia,ib:int64;
+{$else}
 {$ifdef unix}
 var tv:timeval;
     tz:timezone;
     ia,ib:int64;
+{$endif}
 {$endif}
 {$endif}
 begin
@@ -10457,6 +10469,12 @@ begin
  ib:=NowTimeSpec.tv_nsec;
  result:=ia+ib;
 {$else}
+{$ifdef android}
+clock_gettime(CLOCK_MONOTONIC,@NowTimeSpec);
+ia:=int64(NowTimeSpec.tv_sec)*int64(1000000000);
+ib:=NowTimeSpec.tv_nsec;
+result:=ia+ib;
+{$else}
 {$ifdef unix}
   tz.tz_minuteswest:=0;
   tz.tz_dsttime:=0;
@@ -10466,6 +10484,7 @@ begin
   result:=ia+ib;
 {$else}
  result:=SDL_GetTicks;
+{$endif}
 {$endif}
 {$endif}
 {$endif}


### PR DESCRIPTION
Android has three clocks (https://developer.android.com/reference/android/os/SystemClock.html). And clock used by `fpgettimeofday` can leaps forward or backward. We had this issue in CGE too (https://github.com/castle-engine/castle-engine/pull/132). The solution is to use `clock_gettime` More info: https://stackoverflow.com/questions/3832097/how-to-get-the-current-time-in-native-android-code
