### PR TITLE
Fixed crash when you add rigid body that collides with other and remove it in the same physics step.

### DIFF
--- a/src/kraft.pas
+++ b/src/kraft.pas
@@ -1876,8 +1876,11 @@ type PKraftForceMode=^TKraftForceMode;
        procedure UpdatePairs; {$ifdef caninline}inline;{$endif}
 
        procedure StaticBufferMove(ProxyID:longint); {$ifdef caninline}inline;{$endif}
+       procedure StaticBufferClearMove(ProxyID:longint); {$ifdef caninline}inline;{$endif}
        procedure DynamicBufferMove(ProxyID:longint); {$ifdef caninline}inline;{$endif}
+       procedure DynamicBufferClearMove(ProxyID:longint); {$ifdef caninline}inline;{$endif}
        procedure KinematicBufferMove(ProxyID:longint); {$ifdef caninline}inline;{$endif}
+       procedure KinematicBufferClearMove(ProxyID:longint); {$ifdef caninline}inline;{$endif}
 
      end;
 
@@ -18960,6 +18963,8 @@ begin
  end;
 
  if fStaticAABBTreeProxy>=0 then begin
+  if fPhysics.NewShapes then
+   fPhysics.fBroadPhase.StaticBufferClearMove(fStaticAABBTreeProxy);
   fPhysics.fStaticAABBTree.DestroyProxy(fStaticAABBTreeProxy);
   fStaticAABBTreeProxy:=-1;
  end;
@@ -18970,11 +18975,15 @@ begin
  end;
 
  if fDynamicAABBTreeProxy>=0 then begin
+  if fPhysics.NewShapes then
+    fPhysics.fBroadPhase.DynamicBufferClearMove(fDynamicAABBTreeProxy);
   fPhysics.fDynamicAABBTree.DestroyProxy(fDynamicAABBTreeProxy);
   fDynamicAABBTreeProxy:=-1;
  end;
 
  if fKinematicAABBTreeProxy>=0 then begin
+   if fPhysics.NewShapes then
+    fPhysics.fBroadPhase.KinematicBufferClearMove(fKinematicAABBTreeProxy);
   fPhysics.fKinematicAABBTree.DestroyProxy(fKinematicAABBTreeProxy);
   fKinematicAABBTreeProxy:=-1;
  end;
@@ -24504,6 +24513,21 @@ begin
  fStaticMoveBuffer[Index]:=ProxyID;
 end;
 
+procedure TKraftBroadPhase.StaticBufferClearMove(ProxyID:longint);
+var I:integer;
+begin
+  I:=0;
+  while I<fStaticMoveBufferSize do begin
+    if fStaticMoveBuffer[I]=ProxyID then begin
+      if I<>fStaticMoveBufferSize-1 then
+        move(fStaticMoveBuffer[I+1],fStaticMoveBuffer[I],SizeOf(fStaticMoveBuffer[I])*(fStaticMoveBufferSize-I));
+      Dec(fStaticMoveBufferSize);
+      continue;
+    end;
+    Inc(I);
+  end;
+end;
+
 procedure TKraftBroadPhase.DynamicBufferMove(ProxyID:longint);
 var Index:longint;
 begin
@@ -24515,6 +24539,21 @@ begin
  fDynamicMoveBuffer[Index]:=ProxyID;
 end;
 
+procedure TKraftBroadPhase.DynamicBufferClearMove(ProxyID:longint);
+var I:integer;
+begin
+  I:=0;
+  while I<fDynamicMoveBufferSize do begin
+    if fDynamicMoveBuffer[I]=ProxyID then begin
+      if I<>fDynamicMoveBufferSize-1 then
+        move(fDynamicMoveBuffer[I+1],fDynamicMoveBuffer[I],SizeOf(fDynamicMoveBuffer[I])*(fDynamicMoveBufferSize-I));
+      Dec(fDynamicMoveBufferSize);
+      continue;
+    end;
+    Inc(I);
+  end;
+end;
+
 procedure TKraftBroadPhase.KinematicBufferMove(ProxyID:longint);
 var Index:longint;
 begin
@@ -24524,6 +24563,21 @@ begin
   SetLength(fKinematicMoveBuffer,fKinematicMoveBufferSize*2);
  end;
  fKinematicMoveBuffer[Index]:=ProxyID;
+end;
+
+procedure TKraftBroadPhase.KinematicBufferClearMove(ProxyID:longint);
+var I:integer;
+begin
+  I:=0;
+  while I<fKinematicMoveBufferSize do begin
+    if fKinematicMoveBuffer[I]=ProxyID then begin
+      if I<>fKinematicMoveBufferSize-1 then
+        move(fKinematicMoveBuffer[I+1],fKinematicMoveBuffer[I],SizeOf(fKinematicMoveBuffer[I])*(fKinematicMoveBufferSize-I));
+      Dec(fKinematicMoveBufferSize);
+      continue;
+    end;
+    Inc(I);
+  end;
 end;
 
 constructor TKraftRigidBody.Create(const APhysics:TKraft);


### PR DESCRIPTION
This PR fixes crash after add and remove rigid body in the same physics step. I have this problem in my game in Castle Game Engine. When level starts I show "Get ready", start timer and set `SceneManager.TimeScale := 0;`. But user can go back to menu and select another level in this case Kraft rigid bodies are created and destroyed without making physics step. That make Kraft crash, when added and removed body was in collision with something else.

The reason for the crash is AABB box not removed from broad phase:
When you add `TKraftRigidBody` with new shape to Kraft physics (In `TKraftRigidBody.Finish`) it's calls `TKraftShape.SynchronizeProxies`. This procedure creates AABB box, adds it to proper AABBDynamicTree and to `fPhysics.fBroadPhase`. 
Destruction of the shape remove AABB box from AABB dynamic tree, but not remove it from `fPhysics.fBroadPhase`. When next physics step come physics engine try to make contact pair with this not existing rigid body and crashes.

More info and CGE example code in this PR:
https://github.com/castle-engine/castle-engine/pull/138
