### PR TITLE
Fix checking sensors flags in TKraft.BuildIsland

### DIFF
--- a/src/kraft.pas
+++ b/src/kraft.pas
@@ -32312,7 +32312,8 @@ begin
      // Skip contacts that have been added to an island already and we can safely skip contacts if these didn't actually collide with anything,
      // and skip also sensors
      if ((ContactPair^.Flags*[kcfColliding,kcfInIsland])=[kcfColliding]) and
-        not ((ksfSensor in ContactPair^.Shapes[0].fFlags) or
+        not ((krbfSensor in ContactPairEdge^.OtherRigidBody.fFlags) or
+             (ksfSensor in ContactPair^.Shapes[0].fFlags) or
              (ksfSensor in ContactPair^.Shapes[1].fFlags)) then begin
       ContactPair^.Flags:=ContactPair^.Flags+[kcfInIsland];
       Island.AddContactPair(ContactPair);


### PR DESCRIPTION
This PR, fixed crash after add new body and contact with sensor (when sensor is set in rigid body flags).

You can reproduce the bug in platformer example in https://github.com/castle-engine/castle-engine when you change kraft.pas in src/physics/kraft to upstream version. After starting the game make a shoot and try get a coin -> crash in kraft.