### PR TITLE
Fix SphereCast() with mesh shapes.

### DIFF
--- a/src/kraft.pas
+++ b/src/kraft.pas
@@ -11670,7 +11670,7 @@ begin
     result:=false;
     exit;
    end else begin
-    Time:=-t;
+    Time:=t;
     aU:=U;
     aV:=V;
     result:=true;


### PR DESCRIPTION
Hello,

I tried to use `SphereCast()` but it sometimes not works for me. I found the problem is in `function SphereCastTriangle()`. We have here code: 
```
   if t<0.0 then begin
    result:=false;
    exit;
   end else begin
    Time:=-t;
    aU:=U;
    aV:=V;
    result:=true;
    exit;
   end;
```

But in function that call it (`TKraftShapeMesh.SphereCast()`) there is a condition `(Time>=0.0)`:
```
       if SphereCastTriangle(Origin,
                             Radius,
                             Direction,
                             fMesh.fVertices[Triangle^.Vertices[DoubleSidedTriangleVertexOrderIndices[SidePass,0]]],
                             fMesh.fVertices[Triangle^.Vertices[DoubleSidedTriangleVertexOrderIndices[SidePass,1]]],
                             fMesh.fVertices[Triangle^.Vertices[DoubleSidedTriangleVertexOrderIndices[SidePass,2]]],
                             Time,
                             u,
                             v) then begin
        p:=Vector3Add(Origin,Vector3ScalarMul(Direction,Time));
        if ((Time>=0.0) and (Time<=SphereCastData.MaxTime)) and (First or (Time<Nearest)) then
        begin

```

So when `t` is greater than `0` it changes it sign and always is negative. 
My fix is to change that line to:
```
Time:=t;
```
After that `SphereCast()` works perfectly.
My test case project is CGE simple game located in `examples/physics/physics_3d_shooter` in [physics_walk_navigation](https://github.com/castle-engine/castle-engine/tree/physics_walk_navigation) branch commit 6fea532ae3550102bf3b6916c8a489a0022fe2ba.

 
