### PR TITLE
Fix crash in DoNarrowPhase() after removing TKraftShape that has mesh contact.

### DIFF
--- a/src/kraft.pas
+++ b/src/kraft.pas
@@ -33667,6 +33667,11 @@ begin
  end else if fContactPairLast=AContactPair then begin
   fContactPairLast:=AContactPair^.Previous;
  end;
+
+ if AContactPair^.MeshContactPair<>nil then begin
+  RemoveMeshContact(AContactPair^.MeshContactPair);
+ end;
+
  AContactPair^.Previous:=nil;
  AContactPair^.Next:=fFreeContactPairs;
  fFreeContactPairs:=AContactPair;


### PR DESCRIPTION
Hi, 
I found a crash in Kraft when I have mesh collider and I remove `TKraftShape` from other rigid body that collides with mesh collider. The fix removes MeshContactPair when we remove contact pair.

### Where is the crash exactly?
It crashes in `DoNarrowPhase()` in the mesh contact pair loop when it get pointer to non-existent `TKraftShape` and tries get `ShapeA.ProxyFatWorldAABB^`  (`if not AABBIntersect(ShapeA.ProxyFatWorldAABB^,ShapeB.ProxyFatWorldAABB^) then begin`)